### PR TITLE
feat(policies): enable a policy approval workflow via chat

### DIFF
--- a/internal/api/apitest/mock_client.go
+++ b/internal/api/apitest/mock_client.go
@@ -26,6 +26,8 @@ type MockClient struct {
 	CreateMessageFunc                       func(ctx context.Context, input gen.CreateMessageInput) (*gen.CreateMessageResponse, error)
 	EnableServiceFunc                       func(ctx context.Context, serviceID string) (*gen.EnableServiceResponse, error)
 	DisableServiceFunc                      func(ctx context.Context, serviceID string) (*gen.DisableServiceResponse, error)
+	ApproveLogEventPolicyFunc               func(ctx context.Context, policyID string) (*gen.ApproveLogEventPolicyResponse, error)
+	DismissLogEventPolicyFunc               func(ctx context.Context, policyID string) (*gen.DismissLogEventPolicyResponse, error)
 }
 
 // NewMockClient creates a MockClient with sensible defaults.
@@ -147,6 +149,20 @@ func (m *MockClient) EnableService(ctx context.Context, serviceID string) (*gen.
 func (m *MockClient) DisableService(ctx context.Context, serviceID string) (*gen.DisableServiceResponse, error) {
 	if m.DisableServiceFunc != nil {
 		return m.DisableServiceFunc(ctx, serviceID)
+	}
+	return nil, nil
+}
+
+func (m *MockClient) ApproveLogEventPolicy(ctx context.Context, policyID string) (*gen.ApproveLogEventPolicyResponse, error) {
+	if m.ApproveLogEventPolicyFunc != nil {
+		return m.ApproveLogEventPolicyFunc(ctx, policyID)
+	}
+	return nil, nil
+}
+
+func (m *MockClient) DismissLogEventPolicy(ctx context.Context, policyID string) (*gen.DismissLogEventPolicyResponse, error) {
+	if m.DismissLogEventPolicyFunc != nil {
+		return m.DismissLogEventPolicyFunc(ctx, policyID)
 	}
 	return nil, nil
 }

--- a/internal/api/apitest/mock_policies.go
+++ b/internal/api/apitest/mock_policies.go
@@ -1,0 +1,34 @@
+package apitest
+
+import (
+	"context"
+
+	"github.com/usetero/cli/internal/api"
+)
+
+// MockPolicies is a mock implementation of api.Policies.
+type MockPolicies struct {
+	ApprovePolicyFunc func(ctx context.Context, policyID string) error
+	DismissPolicyFunc func(ctx context.Context, policyID string) error
+}
+
+var _ api.Policies = (*MockPolicies)(nil)
+
+// NewMockPolicies creates a MockPolicies with sensible defaults.
+func NewMockPolicies() *MockPolicies {
+	return &MockPolicies{}
+}
+
+func (m *MockPolicies) ApprovePolicy(ctx context.Context, policyID string) error {
+	if m.ApprovePolicyFunc != nil {
+		return m.ApprovePolicyFunc(ctx, policyID)
+	}
+	return nil
+}
+
+func (m *MockPolicies) DismissPolicy(ctx context.Context, policyID string) error {
+	if m.DismissPolicyFunc != nil {
+		return m.DismissPolicyFunc(ctx, policyID)
+	}
+	return nil
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -55,6 +55,10 @@ type Client interface {
 	// Service operations
 	EnableService(ctx context.Context, serviceID string) (*gen.EnableServiceResponse, error)
 	DisableService(ctx context.Context, serviceID string) (*gen.DisableServiceResponse, error)
+
+	// Policy operations
+	ApproveLogEventPolicy(ctx context.Context, policyID string) (*gen.ApproveLogEventPolicyResponse, error)
+	DismissLogEventPolicy(ctx context.Context, policyID string) (*gen.DismissLogEventPolicyResponse, error)
 }
 
 // client is the concrete implementation of Client.
@@ -282,4 +286,22 @@ func (c *client) DisableService(ctx context.Context, serviceID string) (*gen.Dis
 		return nil, err
 	}
 	return gen.DisableService(ctx, gql, serviceID)
+}
+
+// Policy operations
+
+func (c *client) ApproveLogEventPolicy(ctx context.Context, policyID string) (*gen.ApproveLogEventPolicyResponse, error) {
+	gql, err := c.gql(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return gen.ApproveLogEventPolicy(ctx, gql, policyID)
+}
+
+func (c *client) DismissLogEventPolicy(ctx context.Context, policyID string) (*gen.DismissLogEventPolicyResponse, error) {
+	gql, err := c.gql(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return gen.DismissLogEventPolicy(ctx, gql, policyID)
 }

--- a/internal/api/gen/generated.go
+++ b/internal/api/gen/generated.go
@@ -11,6 +11,49 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// ApproveLogEventPolicyApproveLogEventPolicy includes the requested fields of the GraphQL type LogEventPolicy.
+type ApproveLogEventPolicyApproveLogEventPolicy struct {
+	// Unique identifier
+	Id string `json:"id"`
+	// When this policy was approved by a user
+	ApprovedAt *time.Time `json:"approvedAt"`
+	// User ID who approved this policy
+	ApprovedBy *string `json:"approvedBy"`
+	// When this policy was dismissed by a user
+	DismissedAt *time.Time `json:"dismissedAt"`
+	// User ID who dismissed this policy
+	DismissedBy *string `json:"dismissedBy"`
+}
+
+// GetId returns ApproveLogEventPolicyApproveLogEventPolicy.Id, and is useful for accessing the field via an interface.
+func (v *ApproveLogEventPolicyApproveLogEventPolicy) GetId() string { return v.Id }
+
+// GetApprovedAt returns ApproveLogEventPolicyApproveLogEventPolicy.ApprovedAt, and is useful for accessing the field via an interface.
+func (v *ApproveLogEventPolicyApproveLogEventPolicy) GetApprovedAt() *time.Time { return v.ApprovedAt }
+
+// GetApprovedBy returns ApproveLogEventPolicyApproveLogEventPolicy.ApprovedBy, and is useful for accessing the field via an interface.
+func (v *ApproveLogEventPolicyApproveLogEventPolicy) GetApprovedBy() *string { return v.ApprovedBy }
+
+// GetDismissedAt returns ApproveLogEventPolicyApproveLogEventPolicy.DismissedAt, and is useful for accessing the field via an interface.
+func (v *ApproveLogEventPolicyApproveLogEventPolicy) GetDismissedAt() *time.Time {
+	return v.DismissedAt
+}
+
+// GetDismissedBy returns ApproveLogEventPolicyApproveLogEventPolicy.DismissedBy, and is useful for accessing the field via an interface.
+func (v *ApproveLogEventPolicyApproveLogEventPolicy) GetDismissedBy() *string { return v.DismissedBy }
+
+// ApproveLogEventPolicyResponse is returned by ApproveLogEventPolicy on success.
+type ApproveLogEventPolicyResponse struct {
+	// Approve a log event policy, enabling it for enforcement.
+	// Clears any previous dismissal.
+	ApproveLogEventPolicy ApproveLogEventPolicyApproveLogEventPolicy `json:"approveLogEventPolicy"`
+}
+
+// GetApproveLogEventPolicy returns ApproveLogEventPolicyResponse.ApproveLogEventPolicy, and is useful for accessing the field via an interface.
+func (v *ApproveLogEventPolicyResponse) GetApproveLogEventPolicy() ApproveLogEventPolicyApproveLogEventPolicy {
+	return v.ApproveLogEventPolicy
+}
+
 // A content block in a message. Exactly one of the typed fields should be set.
 type ContentBlockInput struct {
 	Type       ContentBlockType    `json:"type"`
@@ -543,6 +586,49 @@ func (v *DisableServiceUpdateService) GetName() string { return v.Name }
 
 // GetEnabled returns DisableServiceUpdateService.Enabled, and is useful for accessing the field via an interface.
 func (v *DisableServiceUpdateService) GetEnabled() bool { return v.Enabled }
+
+// DismissLogEventPolicyDismissLogEventPolicy includes the requested fields of the GraphQL type LogEventPolicy.
+type DismissLogEventPolicyDismissLogEventPolicy struct {
+	// Unique identifier
+	Id string `json:"id"`
+	// When this policy was dismissed by a user
+	DismissedAt *time.Time `json:"dismissedAt"`
+	// User ID who dismissed this policy
+	DismissedBy *string `json:"dismissedBy"`
+	// When this policy was approved by a user
+	ApprovedAt *time.Time `json:"approvedAt"`
+	// User ID who approved this policy
+	ApprovedBy *string `json:"approvedBy"`
+}
+
+// GetId returns DismissLogEventPolicyDismissLogEventPolicy.Id, and is useful for accessing the field via an interface.
+func (v *DismissLogEventPolicyDismissLogEventPolicy) GetId() string { return v.Id }
+
+// GetDismissedAt returns DismissLogEventPolicyDismissLogEventPolicy.DismissedAt, and is useful for accessing the field via an interface.
+func (v *DismissLogEventPolicyDismissLogEventPolicy) GetDismissedAt() *time.Time {
+	return v.DismissedAt
+}
+
+// GetDismissedBy returns DismissLogEventPolicyDismissLogEventPolicy.DismissedBy, and is useful for accessing the field via an interface.
+func (v *DismissLogEventPolicyDismissLogEventPolicy) GetDismissedBy() *string { return v.DismissedBy }
+
+// GetApprovedAt returns DismissLogEventPolicyDismissLogEventPolicy.ApprovedAt, and is useful for accessing the field via an interface.
+func (v *DismissLogEventPolicyDismissLogEventPolicy) GetApprovedAt() *time.Time { return v.ApprovedAt }
+
+// GetApprovedBy returns DismissLogEventPolicyDismissLogEventPolicy.ApprovedBy, and is useful for accessing the field via an interface.
+func (v *DismissLogEventPolicyDismissLogEventPolicy) GetApprovedBy() *string { return v.ApprovedBy }
+
+// DismissLogEventPolicyResponse is returned by DismissLogEventPolicy on success.
+type DismissLogEventPolicyResponse struct {
+	// Dismiss a log event policy, hiding it from pending review.
+	// Clears any previous approval.
+	DismissLogEventPolicy DismissLogEventPolicyDismissLogEventPolicy `json:"dismissLogEventPolicy"`
+}
+
+// GetDismissLogEventPolicy returns DismissLogEventPolicyResponse.DismissLogEventPolicy, and is useful for accessing the field via an interface.
+func (v *DismissLogEventPolicyResponse) GetDismissLogEventPolicy() DismissLogEventPolicyDismissLogEventPolicy {
+	return v.DismissLogEventPolicy
+}
 
 // EnableServiceResponse is returned by EnableService on success.
 type EnableServiceResponse struct {
@@ -2228,6 +2314,14 @@ var AllWorkspacePurpose = []WorkspacePurpose{
 	WorkspacePurposeCompliance,
 }
 
+// __ApproveLogEventPolicyInput is used internally by genqlient
+type __ApproveLogEventPolicyInput struct {
+	Id string `json:"id"`
+}
+
+// GetId returns __ApproveLogEventPolicyInput.Id, and is useful for accessing the field via an interface.
+func (v *__ApproveLogEventPolicyInput) GetId() string { return v.Id }
+
 // __CreateAccountInput is used internally by genqlient
 type __CreateAccountInput struct {
 	Input CreateAccountInput `json:"input"`
@@ -2285,6 +2379,14 @@ type __DisableServiceInput struct {
 
 // GetServiceId returns __DisableServiceInput.ServiceId, and is useful for accessing the field via an interface.
 func (v *__DisableServiceInput) GetServiceId() string { return v.ServiceId }
+
+// __DismissLogEventPolicyInput is used internally by genqlient
+type __DismissLogEventPolicyInput struct {
+	Id string `json:"id"`
+}
+
+// GetId returns __DismissLogEventPolicyInput.Id, and is useful for accessing the field via an interface.
+func (v *__DismissLogEventPolicyInput) GetId() string { return v.Id }
 
 // __EnableServiceInput is used internally by genqlient
 type __EnableServiceInput struct {
@@ -2361,6 +2463,45 @@ type __ValidateDatadogApiKeyInput struct {
 
 // GetInput returns __ValidateDatadogApiKeyInput.Input, and is useful for accessing the field via an interface.
 func (v *__ValidateDatadogApiKeyInput) GetInput() ValidateDatadogApiKeyInput { return v.Input }
+
+// The mutation executed by ApproveLogEventPolicy.
+const ApproveLogEventPolicy_Operation = `
+mutation ApproveLogEventPolicy ($id: ID!) {
+	approveLogEventPolicy(id: $id) {
+		id
+		approvedAt
+		approvedBy
+		dismissedAt
+		dismissedBy
+	}
+}
+`
+
+// Mutation to approve a log event policy for enforcement
+func ApproveLogEventPolicy(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	id string,
+) (data_ *ApproveLogEventPolicyResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ApproveLogEventPolicy",
+		Query:  ApproveLogEventPolicy_Operation,
+		Variables: &__ApproveLogEventPolicyInput{
+			Id: id,
+		},
+	}
+
+	data_ = &ApproveLogEventPolicyResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
 
 // The mutation executed by CreateAccount.
 const CreateAccount_Operation = `
@@ -2616,6 +2757,45 @@ func DisableService(
 	}
 
 	data_ = &DisableServiceResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The mutation executed by DismissLogEventPolicy.
+const DismissLogEventPolicy_Operation = `
+mutation DismissLogEventPolicy ($id: ID!) {
+	dismissLogEventPolicy(id: $id) {
+		id
+		dismissedAt
+		dismissedBy
+		approvedAt
+		approvedBy
+	}
+}
+`
+
+// Mutation to dismiss a log event policy from pending review
+func DismissLogEventPolicy(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	id string,
+) (data_ *DismissLogEventPolicyResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "DismissLogEventPolicy",
+		Query:  DismissLogEventPolicy_Operation,
+		Variables: &__DismissLogEventPolicyInput{
+			Id: id,
+		},
+	}
+
+	data_ = &DismissLogEventPolicyResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/api/gen/queries/log_event_policies.graphql
+++ b/internal/api/gen/queries/log_event_policies.graphql
@@ -1,0 +1,21 @@
+# Mutation to approve a log event policy for enforcement
+mutation ApproveLogEventPolicy($id: ID!) {
+    approveLogEventPolicy(id: $id) {
+        id
+        approvedAt
+        approvedBy
+        dismissedAt
+        dismissedBy
+    }
+}
+
+# Mutation to dismiss a log event policy from pending review
+mutation DismissLogEventPolicy($id: ID!) {
+    dismissLogEventPolicy(id: $id) {
+        id
+        dismissedAt
+        dismissedBy
+        approvedAt
+        approvedBy
+    }
+}

--- a/internal/api/policy_service.go
+++ b/internal/api/policy_service.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/usetero/cli/internal/log"
+)
+
+type Policies interface {
+	// ApprovePolicy approves a policy with the given ID.
+	ApprovePolicy(ctx context.Context, policyID string) error
+	// DismissPolicy dismisses a policy with the given ID.
+	DismissPolicy(ctx context.Context, policyID string) error
+}
+
+type PolicyService struct {
+	client Client
+	scope  log.Scope
+}
+
+// Ensure PolicyService implements Policies.
+var _ Policies = (*PolicyService)(nil)
+
+// NewPolicyService creates a new policy service.
+func NewPolicyService(client Client, scope log.Scope) *PolicyService {
+	return &PolicyService{
+		client: client,
+		scope:  scope.Child("policies"),
+	}
+}
+
+// ApprovePolicy approves a log event policy.
+func (s *PolicyService) ApprovePolicy(ctx context.Context, id string) error {
+	s.scope.Debug("approving policy via API", "id", id)
+
+	_, err := s.client.ApproveLogEventPolicy(ctx, id)
+	if err != nil {
+		s.scope.Error("failed to approve policy", "error", err, "id", id)
+		if classified := classifyError(err); classified != nil {
+			return fmt.Errorf("approve policy %s: %w", id, classified)
+		}
+		return err
+	}
+
+	s.scope.Debug("approved policy via API", "id", id)
+	return nil
+}
+
+// DismissPolicy dismisses a log event policy.
+func (s *PolicyService) DismissPolicy(ctx context.Context, id string) error {
+	s.scope.Debug("dismissing policy via API", "id", id)
+
+	_, err := s.client.DismissLogEventPolicy(ctx, id)
+	if err != nil {
+		s.scope.Error("failed to dismiss policy", "error", err, "id", id)
+		if classified := classifyError(err); classified != nil {
+			return fmt.Errorf("dismiss policy %s: %w", id, classified)
+		}
+		return err
+	}
+
+	s.scope.Debug("dismissed policy via API", "id", id)
+	return nil
+}

--- a/internal/api/services.go
+++ b/internal/api/services.go
@@ -19,6 +19,7 @@ type APIServices struct {
 	Conversations   Conversations
 	Messages        Messages
 	Services        Services
+	Policies        Policies
 }
 
 // NewServices creates APIServices with an internally-managed client.
@@ -45,6 +46,7 @@ func newAPIServices(client Client, scope log.Scope) APIServices {
 		Conversations:   NewConversationService(client, scope),
 		Messages:        NewMessageService(client, scope),
 		Services:        NewServiceService(client, scope),
+		Policies:        NewPolicyService(client, scope),
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -311,6 +311,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			chattools.NewShowTool(m.db),
 			map[string]chattools.ActionTool{
 				"set_service_enabled": chattools.NewSetServiceEnabledAction(m.db),
+				"approve_policy": chattools.NewApprovePolicyAction(m.db, func() string {
+					if m.user != nil {
+						return m.user.ID
+					}
+					return ""
+				}),
 			},
 		)
 
@@ -504,7 +510,7 @@ func (m *Model) startSync(accountID string) error {
 	psClient := psapi.NewClient(m.cfg.PowerSyncEndpoint)
 
 	// Create and start uploader
-	m.uploader = upload.New(m.db, psClient, m.authService, m.services.Conversations, m.services.Messages, m.services.Services, m.scope)
+	m.uploader = upload.New(m.db, psClient, m.authService, m.services.Conversations, m.services.Messages, m.services.Services, m.services.Policies, m.scope)
 	go func() {
 		if err := m.uploader.Run(sessionCtx); err != nil && !errors.Is(err, context.Canceled) {
 			m.scope.Error("uploader error", "error", err)

--- a/internal/app/statusbar/services/services.go
+++ b/internal/app/statusbar/services/services.go
@@ -458,4 +458,3 @@ func (m *Model) renderVolume(svc domain.ServiceStatus) string {
 	}
 	return vol
 }
-

--- a/internal/chat/tools/approvepolicy.go
+++ b/internal/chat/tools/approvepolicy.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/usetero/cli/internal/app/chat/messagelist/round/turn/assistant/blocks/tools/action"
+	"github.com/usetero/cli/internal/chat"
+	"github.com/usetero/cli/internal/domain/tools"
+	"github.com/usetero/cli/internal/sqlite"
+)
+
+// NewApprovePolicyAction creates an ActionTool for approve_policy.
+// userIDFunc is called at execution time to get the current user's ID.
+func NewApprovePolicyAction(db sqlite.DB, userIDFunc func() string) ActionTool {
+	def := chat.Tool{
+		Name:        "approve_policy",
+		Description: "Approve a log event policy for enforcement. This marks the policy as approved and queues it for the enforcement pipeline.",
+		InputSchema: chat.NewObjectSchema(
+			map[string]chat.Property{
+				"policy_id": {
+					Type:        "string",
+					Description: "UUID of the policy (e.g., '4a3b1c2d-...'). Use the query tool to look up policy IDs: SELECT policy_id, service_name, log_event_name, category FROM log_event_policy_statuses_cache WHERE status = 'PENDING'",
+				},
+			},
+			[]string{"policy_id"},
+		),
+	}
+
+	executor := func(input json.RawMessage) (tools.Result, error) {
+		var in tools.ApprovePolicyInput
+		if err := json.Unmarshal(input, &in); err != nil {
+			return tools.Result{}, err
+		}
+
+		ctx := context.Background()
+
+		if err := db.LogEventPolicies().Approve(ctx, in.PolicyID, userIDFunc()); err != nil {
+			return tools.Result{}, fmt.Errorf("approve policy: %w", err)
+		}
+
+		return tools.Result{
+			Content: tools.ApprovePolicyResult{
+				PolicyID: in.PolicyID,
+				Status:   "APPROVED",
+			}.ToMap(),
+		}, nil
+	}
+
+	config := action.Config{
+		DisplayName: func(_ json.RawMessage) string {
+			return "Approve Policy"
+		},
+		Status: func(input json.RawMessage) string {
+			var in tools.ApprovePolicyInput
+			if json.Unmarshal(input, &in) != nil {
+				return ""
+			}
+			return fmt.Sprintf("Approving %s", in.PolicyID)
+		},
+		Result: func(result tools.Result) string {
+			id, _ := result.Content["policy_id"].(string)
+			return fmt.Sprintf("Policy %s approved", id)
+		},
+	}
+
+	return NewActionTool(def, executor, config)
+}

--- a/internal/domain/tools/approvepolicy.go
+++ b/internal/domain/tools/approvepolicy.go
@@ -1,0 +1,20 @@
+package tools
+
+// ApprovePolicyInput is the input schema for the approve_policy tool.
+type ApprovePolicyInput struct {
+	PolicyID string `json:"policy_id"`
+}
+
+// ApprovePolicyResult is the typed output of an approve_policy tool execution.
+type ApprovePolicyResult struct {
+	PolicyID string `json:"policy_id"`
+	Status   string `json:"status"`
+}
+
+// ToMap serializes the result for the GraphQL API.
+func (r ApprovePolicyResult) ToMap() map[string]any {
+	return map[string]any{
+		"policy_id": r.PolicyID,
+		"status":    r.Status,
+	}
+}

--- a/internal/sqlite/database.go
+++ b/internal/sqlite/database.go
@@ -278,7 +278,7 @@ func (d *database) LogEvents() LogEvents {
 
 // LogEventPolicies returns type-safe log event policy operations.
 func (d *database) LogEventPolicies() LogEventPolicies {
-	return &logEventPoliciesImpl{queries: d.ReadQueries()}
+	return &logEventPoliciesImpl{read: d.ReadQueries(), write: d.WriteQueries()}
 }
 
 // LogEventPolicyStatuses returns type-safe pre-computed policy status data.

--- a/internal/sqlite/gen/log_event_policies.sql.go
+++ b/internal/sqlite/gen/log_event_policies.sql.go
@@ -9,6 +9,23 @@ import (
 	"context"
 )
 
+const approveLogEventPolicy = `-- name: ApproveLogEventPolicy :exec
+UPDATE log_event_policies
+SET approved_at = ?, approved_by = ?
+WHERE id = ?
+`
+
+type ApproveLogEventPolicyParams struct {
+	ApprovedAt *string
+	ApprovedBy *string
+	ID         *string
+}
+
+func (q *Queries) ApproveLogEventPolicy(ctx context.Context, arg ApproveLogEventPolicyParams) error {
+	_, err := q.db.ExecContext(ctx, approveLogEventPolicy, arg.ApprovedAt, arg.ApprovedBy, arg.ID)
+	return err
+}
+
 const countLogEventPolicies = `-- name: CountLogEventPolicies :one
 SELECT COUNT(*) FROM log_event_policies
 `
@@ -18,4 +35,21 @@ func (q *Queries) CountLogEventPolicies(ctx context.Context) (int64, error) {
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const dismissLogEventPolicy = `-- name: DismissLogEventPolicy :exec
+UPDATE log_event_policies
+SET dismissed_at = ?, dismissed_by = ?
+WHERE id = ?
+`
+
+type DismissLogEventPolicyParams struct {
+	DismissedAt *string
+	DismissedBy *string
+	ID          *string
+}
+
+func (q *Queries) DismissLogEventPolicy(ctx context.Context, arg DismissLogEventPolicyParams) error {
+	_, err := q.db.ExecContext(ctx, dismissLogEventPolicy, arg.DismissedAt, arg.DismissedBy, arg.ID)
+	return err
 }

--- a/internal/sqlite/gen/querier.go
+++ b/internal/sqlite/gen/querier.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Querier interface {
+	ApproveLogEventPolicy(ctx context.Context, arg ApproveLogEventPolicyParams) error
 	CountConversations(ctx context.Context) (int64, error)
 	CountFixedPIIPolicies(ctx context.Context) (int64, error)
 	CountLogEventPolicies(ctx context.Context) (int64, error)
@@ -17,6 +18,7 @@ type Querier interface {
 	CountMessagesByConversation(ctx context.Context, conversationID *string) (int64, error)
 	CountServices(ctx context.Context) (int64, error)
 	DeleteMessage(ctx context.Context, id *string) error
+	DismissLogEventPolicy(ctx context.Context, arg DismissLogEventPolicyParams) error
 	GetAccountSummary(ctx context.Context) (GetAccountSummaryRow, error)
 	GetConversation(ctx context.Context, id *string) (Conversation, error)
 	GetLatestConversationByAccount(ctx context.Context, accountID *string) (Conversation, error)

--- a/internal/sqlite/log_event_policies.go
+++ b/internal/sqlite/log_event_policies.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"time"
 
 	"github.com/usetero/cli/internal/sqlite/gen"
 )
@@ -9,18 +10,47 @@ import (
 // LogEventPolicies provides type-safe access to log event policies.
 type LogEventPolicies interface {
 	Count(ctx context.Context) (int64, error)
+	Approve(ctx context.Context, id, userID string) error
+	Dismiss(ctx context.Context, id, userID string) error
 }
 
 // logEventPoliciesImpl implements LogEventPolicies.
 type logEventPoliciesImpl struct {
-	queries *gen.Queries
+	read  *gen.Queries
+	write *gen.Queries
 }
 
 // Count returns the total number of log event policies.
 func (l *logEventPoliciesImpl) Count(ctx context.Context) (int64, error) {
-	count, err := l.queries.CountLogEventPolicies(ctx)
+	count, err := l.read.CountLogEventPolicies(ctx)
 	if err != nil {
 		return 0, WrapSQLiteError(err, "count log event policies")
 	}
 	return count, nil
+}
+
+func (l *logEventPoliciesImpl) Approve(ctx context.Context, id, userID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	err := l.write.ApproveLogEventPolicy(ctx, gen.ApproveLogEventPolicyParams{
+		ID:         &id,
+		ApprovedAt: &now,
+		ApprovedBy: &userID,
+	})
+	if err != nil {
+		return WrapSQLiteError(err, "approve log event policy")
+	}
+	return nil
+}
+
+func (l *logEventPoliciesImpl) Dismiss(ctx context.Context, id, userID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	err := l.write.DismissLogEventPolicy(ctx, gen.DismissLogEventPolicyParams{
+		ID:          &id,
+		DismissedAt: &now,
+		DismissedBy: &userID,
+	})
+	if err != nil {
+		return WrapSQLiteError(err, "dismiss log event policy")
+	}
+	return nil
 }

--- a/internal/sqlite/queries/log_event_policies.sql
+++ b/internal/sqlite/queries/log_event_policies.sql
@@ -1,2 +1,12 @@
 -- name: CountLogEventPolicies :one
 SELECT COUNT(*) FROM log_event_policies;
+
+-- name: ApproveLogEventPolicy :exec
+UPDATE log_event_policies
+SET approved_at = ?, approved_by = ?
+WHERE id = ?;
+
+-- name: DismissLogEventPolicy :exec
+UPDATE log_event_policies
+SET dismissed_at = ?, dismissed_by = ?
+WHERE id = ?;

--- a/internal/upload/policy_handler.go
+++ b/internal/upload/policy_handler.go
@@ -1,0 +1,46 @@
+package upload
+
+import (
+	"context"
+
+	"github.com/usetero/cli/internal/api"
+	"github.com/usetero/cli/internal/log"
+	"github.com/usetero/cli/internal/powersync/db"
+)
+
+// policyHandler handles uploading log event policy mutations to the GraphQL API.
+type policyHandler struct {
+	policies api.Policies
+	scope    log.Scope
+}
+
+func newPolicyHandler(policies api.Policies, scope log.Scope) *policyHandler {
+	return &policyHandler{
+		policies: policies,
+		scope:    scope.Child("policies"),
+	}
+}
+
+func (h *policyHandler) Handle(ctx context.Context, entry *db.CrudEntry, emit Emitter) error {
+	_ = emit
+
+	switch entry.Op {
+	case db.OpPatch:
+		return h.handlePatch(ctx, entry)
+	default:
+		h.scope.Warn("unsupported policy op, dropping", "op", entry.Op, "rowId", entry.RowID)
+		return nil
+	}
+}
+
+func (h *policyHandler) handlePatch(ctx context.Context, entry *db.CrudEntry) error {
+	if _, ok := entry.Data["approved_at"]; ok {
+		return h.policies.ApprovePolicy(ctx, entry.RowID)
+	}
+	if _, ok := entry.Data["dismissed_at"]; ok {
+		return h.policies.DismissPolicy(ctx, entry.RowID)
+	}
+
+	h.scope.Warn("no mutation for patched fields, dropping", "rowId", entry.RowID, "fields", fieldNames(entry.Data))
+	return nil
+}

--- a/internal/upload/uploader.go
+++ b/internal/upload/uploader.go
@@ -60,6 +60,7 @@ func New(
 	conversations api.Conversations,
 	messages api.Messages,
 	services api.Services,
+	policies api.Policies,
 	scope log.Scope,
 ) Uploader {
 	scope = scope.Child("upload")
@@ -69,9 +70,10 @@ func New(
 		client:         client,
 		tokenRefresher: tokenRefresher,
 		handlers: map[sqlite.Table]Handler{
-			sqlite.TableConversations: newConversationHandler(conversations, scope),
-			sqlite.TableMessages:      newMessageHandler(messages, database, scope),
-			sqlite.TableServices:      newServiceHandler(services, scope),
+			sqlite.TableConversations:    newConversationHandler(conversations, scope),
+			sqlite.TableMessages:         newMessageHandler(messages, database, scope),
+			sqlite.TableServices:         newServiceHandler(services, scope),
+			sqlite.TableLogEventPolicies: newPolicyHandler(policies, scope),
 		},
 		scope:        scope,
 		pollInterval: defaultPollInterval,

--- a/internal/upload/uploader_integration_test.go
+++ b/internal/upload/uploader_integration_test.go
@@ -122,7 +122,7 @@ func TestIntegration_Upload(t *testing.T) {
 
 		// Start upload loop
 		powersyncClient := powersync.NewClient(cliConfig.PowerSyncEndpoint)
-		uploader := upload.New(db, powersyncClient, authSvc, services.Conversations, messagesSvc, services.Services, logger)
+		uploader := upload.New(db, powersyncClient, authSvc, services.Conversations, messagesSvc, services.Services, services.Policies, logger)
 
 		uploadCtx, uploadCancel := context.WithCancel(ctx)
 		defer uploadCancel()

--- a/internal/upload/uploader_test.go
+++ b/internal/upload/uploader_test.go
@@ -33,6 +33,7 @@ func TestUploader_Run(t *testing.T) {
 			apitest.NewMockConversations(),
 			apitest.NewMockMessages(),
 			apitest.NewMockAPIServiceServices(),
+			apitest.NewMockPolicies(),
 			logtest.NewScope(t),
 		)
 
@@ -57,6 +58,7 @@ func TestUploader_Run(t *testing.T) {
 			apitest.NewMockConversations(),
 			apitest.NewMockMessages(),
 			apitest.NewMockAPIServiceServices(),
+			apitest.NewMockPolicies(),
 			logtest.NewScope(t),
 		)
 
@@ -106,6 +108,7 @@ func TestUploader_Run(t *testing.T) {
 			conversations,
 			apitest.NewMockMessages(),
 			apitest.NewMockAPIServiceServices(),
+			apitest.NewMockPolicies(),
 			logtest.NewScope(t),
 		)
 
@@ -162,6 +165,7 @@ func TestUploader_Run(t *testing.T) {
 			apitest.NewMockConversations(),
 			apitest.NewMockMessages(),
 			apitest.NewMockAPIServiceServices(),
+			apitest.NewMockPolicies(),
 			logtest.NewScope(t),
 		)
 
@@ -227,6 +231,7 @@ func TestUploader_Run(t *testing.T) {
 			conversations,
 			apitest.NewMockMessages(),
 			apitest.NewMockAPIServiceServices(),
+			apitest.NewMockPolicies(),
 			logtest.NewScope(t),
 		)
 


### PR DESCRIPTION
Code pulled from #40 

Conversation thread https://usetero.slack.com/archives/C09UDLPHK5W/p1771894782677739

This allows you to approve a policy from chat, it doesn't yet enable the exclusion filter in DD since that isn't hooked up yet