### PR TITLE
fix(onboarding): restore user state on warm start

### DIFF
--- a/internal/app/onboarding/preflight/preflight_effects.go
+++ b/internal/app/onboarding/preflight/preflight_effects.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	iauth "github.com/usetero/cli/internal/auth"
 	"github.com/usetero/cli/internal/core/bootstrap"
 	"github.com/usetero/cli/internal/domain"
 )
@@ -13,14 +14,18 @@ import (
 func (m *Model) checkAuth() tea.Cmd {
 	return func() tea.Msg {
 		hasValidAuth := false
+		var user *iauth.User
 		if m.auth.IsAuthenticated() {
 			if _, err := m.auth.GetAccessToken(m.ctx); err == nil {
 				hasValidAuth = true
+				if userID, err := m.auth.GetUserID(m.ctx); err == nil && userID != "" {
+					user = &iauth.User{ID: userID}
+				}
 			} else {
 				_ = m.auth.ClearTokens()
 			}
 		}
-		return preflightAuthCheckCompletedMsg{hasValidAuth: hasValidAuth}
+		return preflightAuthCheckCompletedMsg{hasValidAuth: hasValidAuth, user: user}
 	}
 }
 

--- a/internal/app/onboarding/preflight/preflight_types.go
+++ b/internal/app/onboarding/preflight/preflight_types.go
@@ -1,6 +1,7 @@
 package preflight
 
 import (
+	"github.com/usetero/cli/internal/auth"
 	"github.com/usetero/cli/internal/core/bootstrap"
 	"github.com/usetero/cli/internal/domain"
 )
@@ -11,6 +12,7 @@ type preflightResolutionCompletedMsg struct {
 
 type preflightAuthCheckCompletedMsg struct {
 	hasValidAuth bool
+	user         *auth.User
 }
 
 type preflightOrganizationsLoadedMsg struct {

--- a/internal/app/onboarding/preflight/preflight_update.go
+++ b/internal/app/onboarding/preflight/preflight_update.go
@@ -29,6 +29,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 
 func (m *Model) handleAuthChecked(msg preflightAuthCheckCompletedMsg) tea.Cmd {
 	m.state.HasValidAuth = msg.hasValidAuth
+	m.state.User = msg.user
 	if !m.state.HasValidAuth {
 		return m.emitResult()
 	}

--- a/internal/app/onboarding/transitions_test.go
+++ b/internal/app/onboarding/transitions_test.go
@@ -99,6 +99,27 @@ func TestHandleTransitionPreflightRouting(t *testing.T) {
 	}
 }
 
+func TestHandleTransitionPreflightResolvedCarriesUserState(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t)
+	user := ptrUser("user-1")
+
+	cmd := m.handleTransition(bootstrap.PreflightResolved{State: bootstrap.PreflightState{
+		HasValidAuth: true,
+		User:         user,
+		Role:         bootstrap.RolePlatform,
+		Org:          ptrOrg("org-1"),
+		Account:      ptrAccount("acc-1"),
+	}})
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	if m.state.User == nil || m.state.User.ID != user.ID {
+		t.Fatalf("user state = %+v, want %s", m.state.User, user.ID)
+	}
+}
+
 func TestHandleTransitionDatadogBranchRouting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/bootstrap/messages.go
+++ b/internal/core/bootstrap/messages.go
@@ -86,6 +86,7 @@ type OnboardingComplete struct {
 type PreflightState struct {
 	Outcome            PreflightOutcome
 	HasValidAuth       bool
+	User               *auth.User
 	Role               string
 	ActiveOrgID        domain.OrganizationID
 	DefaultAccountID   domain.AccountID

--- a/internal/core/bootstrap/state.go
+++ b/internal/core/bootstrap/state.go
@@ -32,6 +32,9 @@ func ApplyPreflight(state State, resolved PreflightState) (State, Gate) {
 	if resolved.Account != nil {
 		state.Account = resolved.Account
 	}
+	if resolved.User != nil {
+		state.User = resolved.User
+	}
 
 	return state, next
 }


### PR DESCRIPTION
## Summary
- restore authenticated user state during preflight when a valid token already exists
- carry that user through `PreflightResolved` into bootstrap state so sync completion can transition to chat
- add a regression test covering the warm-start preflight path

## Why
Warm starts could reach PowerSync `Ready` and then stall in onboarding. The root cause was that the fresh auth path populated `bootstrap.State.User`, but the preflight path only restored auth validity plus org/account state. After sync completed, onboarding rejected completion because `User` was still nil.

## Implementation details
- extend `bootstrap.PreflightState` with an optional `User`
- in onboarding preflight, call `GetUserID()` after validating the access token and attach a minimal `auth.User{ID: ...}`
- update `ApplyPreflight` to copy that user into bootstrap state
- add a transition test asserting `PreflightResolved` carries user state forward

## Verification
- reproduced the bug locally by authenticating once, quitting, and launching again
- confirmed logs showed `sync completed without required onboarding state has_user=false ...`
- full `go test` was not runnable in this environment because the sandbox could not reach `proxy.golang.org` to fetch modules

## Risk
- low: this only affects the already-authenticated preflight path and only adds user hydration from the existing token
- `auth.User` is populated minimally with `ID` because warm-start completion only requires presence of the user object
